### PR TITLE
Planetiler running improvements

### DIFF
--- a/03_render_planet.sh
+++ b/03_render_planet.sh
@@ -5,10 +5,16 @@ trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 sudo touch logs.txt
 sudo tail -f logs.txt | sudo nc seashells.io 1337 > /tmp/seashells & sleep 10
 
-sudo docker run -e JAVA_TOOL_OPTIONS='-Xmx115g' -v "$(pwd)/data":/data -v /mnt/efs:/output \
-  ghcr.io/onthegomap/planetiler:latest --area=planet --bounds=world \
-  --mbtiles=/output/new-planet.mbtiles \
-  --transportation_name_size_for_shield \
-  --transportation_name_limit_merge \
-  --storage=mmap --nodemap-type=array --building_merge_z13=false | sudo tee -a logs.txt
+run() {
+  set -x
+  sudo docker run -e JAVA_TOOL_OPTIONS='-Xmx30g' -v "$(pwd)/data":/data \
+    ghcr.io/onthegomap/planetiler:latest --area=planet --bounds=world \
+    --mbtiles=/data/new-planet.mbtiles \
+    --transportation_name_size_for_shield \
+    --transportation_name_limit_merge \
+    --storage=mmap --nodemap-type=array --building_merge_z13=false
+  sudo cp /data/new-planet.mbtiles /mnt/efs/new-planet.mbtiles
+}
+
+run | sudo tee -a logs.txt
  

--- a/03_render_planet.sh
+++ b/03_render_planet.sh
@@ -13,8 +13,7 @@ run() {
     --transportation_name_size_for_shield \
     --transportation_name_limit_merge \
     --storage=mmap --nodemap-type=array --building_merge_z13=false
-  sudo cp /data/new-planet.mbtiles /mnt/efs/new-planet.mbtiles
+  sudo time cp /data/new-planet.mbtiles /mnt/efs/new-planet.mbtiles
 }
 
 run | sudo tee -a logs.txt
- 


### PR DESCRIPTION
Improve planetiler stability by using less RAM in mmap mode to make room for the OS to cache memory-mapped files, and have planetiler write to a local file first, then copy to EFS when done.