### PR TITLE
Update osmus_trails.yml

### DIFF
--- a/layers/osmus_trails.yml
+++ b/layers/osmus_trails.yml
@@ -134,7 +134,9 @@ layers:
           highway: cycleway
         exclude_when:
           # ignore bike lanes that are part of roads
-          cycleway: lane
+          cycleway:
+            - lane
+            - crossing
           indoor: __any__
         attributes: *trail_attributes
       - source: osm

--- a/layers/osmus_trails.yml
+++ b/layers/osmus_trails.yml
@@ -12,6 +12,7 @@ layers:
         geometry: line
         min_zoom: 5
         include_when:
+          &trail_include_filter
           highway:
             - bridleway
             - cycleway
@@ -32,84 +33,89 @@ layers:
               ski:nordic: __any__
               wheelchair: __any__
         exclude_when:
+          &trail_exclude_filter
           footway: __any__
           golf: cartpath
           indoor: __any__
         attributes:
           - key: OSM_ID
             value: "${feature.id}"
-          - key: highway
-            tag_value: highway
-          - key: piste:type
-            tag_value: piste:type
-          - key: bridge
-            tag_value: bridge
-          - key: ford
-            tag_value: ford
-          - key: tunnel
-            tag_value: tunnel
-          - key: trailblazed
-            tag_value: trailblazed
-          - key: symbol
-            tag_value: symbol
-          - key: colour
-            tag_value: colour
           - key: access
             tag_value: access
-          - key: toll
-            tag_value: toll
-          - key: foot
-            tag_value: foot
-          - key: bicycle
-            tag_value: bicycle
-          - key: horse
-            tag_value: horse
-          - key: dog
-            tag_value: dog
-          - key: ski
-            tag_value: ski
-          - key: ski:nordic
-            tag_value: ski:nordic
-          - key: inline_skates
-            tag_value: inline_skates
-          - key: vehicle
-            tag_value: vehicle
-          - key: motor_vehicle
-            tag_value: motor_vehicle
           - key: atv
             tag_value: atv
-          - key: motorcycle
-            tag_value: motorcycle
-          - key: moped
-            tag_value: moped
-          - key: motorcar
-            tag_value: motorcar
-          - key: wheelchair
-            tag_value: wheelchair
+          - key: bicycle
+            tag_value: bicycle
+          - key: bridge
+            tag_value: bridge
+          - key: canoe
+            tag_value: canoe
+          - key: dog
+            tag_value: dog
+          - key: foot
+            tag_value: foot
+          - key: ford
+            tag_value: ford
+          - key: highway
+            tag_value: highway
+          - key: hiking
+            tag_value: hiking
+          - key: horse
+            tag_value: horse
+          - key: incline
+            tag_value: incline
+          - key: informal
+            tag_value: informal
+          - key: inline_skates
+            tag_value: inline_skates
+          - key: motor_vehicle
+            tag_value: motor_vehicle
+          - key: mtb
+            tag_value: mtb
           - key: oneway
             tag_value: oneway
           - key: oneway:bicycle
             tag_value: oneway:bicycle
-          - key: incline
-            tag_value: incline
-          - key: width
-            tag_value: width
-          - key: mtb
-            tag_value: mtb
-          - key: surface
-            tag_value: surface
+          - key: oneway:foot
+            tag_value: oneway:foot
+          - key: operator
+            tag_value: operator
+          - key: piste:type
+            tag_value: piste:type
+          - key: ramp:bicycle
+            tag_value: ramp:bicycle
+          - key: ramp:wheelchair
+            tag_value: ramp:wheelchair
+          - key: sac_scale
+            tag_value: sac_scale
+          - key: ski
+            tag_value: ski
+          - key: ski:nordic
+            tag_value: ski:nordic
           - key: smoothness
             tag_value: smoothness
+          - key: snowmobile
+            tag_value: snowmobile
+          - key: surface
+            tag_value: surface
+          - key: symbol
+            tag_value: symbol
+          - key: toll
+            tag_value: toll
           - key: tracktype
             tag_value: tracktype
           - key: trail_visibility
             tag_value: trail_visibility
-          - key: sac_scale
-            tag_value: sac_scale
-          - key: informal
-            tag_value: informal
-          - key: operator
-            tag_value: operator
+          - key: trailblazed
+            tag_value: trailblazed
+          - key: tunnel
+            tag_value: tunnel
+          - key: vehicle
+            tag_value: vehicle
+          - key: wheelchair
+            tag_value: wheelchair
+          - key: width
+            tag_value: width
   - id: trail_name
     features:
       - source: osm
@@ -118,30 +124,8 @@ layers:
         include_when:
           __all__:
             name: __any__
-            __any__:
-              highway:
-                - bridleway
-                - cycleway
-                - footway
-                - path
-                - steps
-                - via_ferrata
-              __all__:
-                # we only care about tracks if they have some trail access tag
-                - highway: track
-                - __any__:
-                  atv: __any__
-                  bicycle: __any__
-                  dog: __any__
-                  foot: __any__
-                  horse: __any__
-                  ski: __any__
-                  ski:nordic: __any__
-                  wheelchair: __any__
-        exclude_when:
-          footway: __any__
-          golf: cartpath
-          indoor: __any__
+            __any__: *trail_include_filter
+        exclude_when: *trail_exclude_filter
         attributes:
           - key: name
             tag_value: name
@@ -152,27 +136,148 @@ layers:
         buffer: 5
   - id: trail_poi
     features:
+      # collect ranger stations mapped as nodes
+      - source: osm
+        geometry: point
+        min_zoom: 5
+        include_when:
+          amenity:
+            - ranger_station
+        exclude_when:
+          highway:
+            - trailhead
+        attributes:
+          - key: OSM_TYPE
+            value: "node"
+          - key: OSM_ID
+            value: "${feature.id}"
+          - key: access
+            tag_value: access
+          - key: amenity
+            tag_value: amenity
+          - key: name
+            tag_value: name
+          - key: opening_hours
+            tag_value: opening_hours
+          - key: operator
+            tag_value: operator
+          - key: wheelchair
+            tag_value: wheelchair
+      # collect ranger stations mapped as areas
+      - source: osm
+        geometry: polygon_centroid_if_convex
+        min_zoom: 5
+        include_when:
+          amenity:
+            - ranger_station
+        attributes:
+          - key: OSM_TYPE
+            value: "way"
+          - key: OSM_ID
+            value: "${feature.id}"
+          - key: access
+            tag_value: access
+          - key: amenity
+            tag_value: amenity
+          - key: name
+            tag_value: name
+          - key: opening_hours
+            tag_value: opening_hours
+          - key: operator
+            tag_value: operator
+          - key: wheelchair
+            tag_value: wheelchair
       - source: osm
         geometry: point
         min_zoom: 7
         include_when:
           highway:
             - trailhead
-          amenity:
-            - ranger_station
         attributes:
           - key: OSM_ID
             value: "${feature.id}"
-          - key: highway
-            tag_value: highway
-          - key: name
-            tag_value: name
           - key: access
             tag_value: access
-          - key: wheelchair
-            tag_value: wheelchair
+          - key: atv
+            tag_value: atv
+          - key: bicycle
+            tag_value: bicycle
+          - key: canoe
+            tag_value: canoe
+          - key: dog
+            tag_value: dog
+          - key: foot
+            tag_value: foot
+          - key: highway
+            tag_value: highway
+          - key: hiking
+            tag_value: hiking
+          - key: horse
+            tag_value: horse
+          - key: information
+            tag_value: information
+          - key: mtb
+            tag_value: mtb
+          - key: name
+            tag_value: name
+          - key: opening_hours
+            tag_value: opening_hours
           - key: operator
             tag_value: operator
+          - key: ski
+            tag_value: ski
+          - key: ski:nordic
+            tag_value: ski:nordic
+          - key: snowmobile
+            tag_value: snowmobile
+          - key: wheelchair
+            tag_value: wheelchair
+      - source: osm
+        geometry: point
+        # route markers are abundant so restrict to higher zooms
+        min_zoom: 12
+        include_when:
+          information:
+            - route_marker
+            - guidepost
+        exclude_when:
+          amenity:
+            - ranger_station
+          highway:
+            - trailhead
+        attributes:
+          - key: OSM_ID
+            value: "${feature.id}"
+          - key: atv
+            tag_value: atv
+          - key: bicycle
+            tag_value: bicycle
+          - key: canoe
+            tag_value: canoe
+          - key: dog
+            tag_value: dog
+          - key: foot
+            tag_value: foot
+          - key: hiking
+            tag_value: hiking
+          - key: horse
+            tag_value: horse
+          - key: information
+            tag_value: information
+          - key: mtb
+            tag_value: mtb
+          - key: name
+            tag_value: name
+          - key: operator
+            tag_value: operator
+          - key: ski
+            tag_value: ski
+          - key: ski:nordic
+            tag_value: ski:nordic
+          - key: snowmobile
+            tag_value: snowmobile
+          - key: wheelchair
+            tag_value: wheelchair
 args:
   area:
     description: Geofabrik area to download

--- a/layers/osmus_trails.yml
+++ b/layers/osmus_trails.yml
@@ -14,6 +14,7 @@ layers:
         include_when:
           &trail_include_filter
           highway:
+            # include any path-like features
             - bridleway
             - cycleway
             - footway
@@ -29,13 +30,21 @@ layers:
               dog: __any__
               foot: __any__
               horse: __any__
+              piste:type: __any__
               ski: __any__
               ski:nordic: __any__
+              snowmobile: __any__
               wheelchair: __any__
+          __all__:
+            # include roads that are part of canoe portages 
+            - highway: __any__
+            - canoe: portage
         exclude_when:
           &trail_exclude_filter
+          # ignore sidewalks, crossings, access aisles, etc.
           footway: __any__
           golf: cartpath
+          # outdoor stuff only
           indoor: __any__
         attributes:
           - key: OSM_ID
@@ -116,6 +125,38 @@ layers:
             tag_value: wheelchair
           - key: width
             tag_value: width
+      - source: osm
+        geometry: line
+        min_zoom: 5
+        include_when:
+          waterway:
+            - river
+            - stream
+            - tidal_channel
+            - canal
+            - drain
+            - ditch
+            - canoe_pass
+            - fairway
+            - link
+          canoe: __any__
+        attributes:
+          - key: OSM_ID
+            value: "${feature.id}"
+          - key: access
+            tag_value: access
+          - key: boat
+            tag_value: boat
+          - key: bridge
+            tag_value: bridge
+          - key: canoe
+            tag_value: canoe
+          - key: dog
+            tag_value: dog
+          - key: tunnel
+            tag_value: tunnel
+          - key: width
+            tag_value: width
   - id: trail_name
     features:
       - source: osm
@@ -141,11 +182,7 @@ layers:
         geometry: point
         min_zoom: 5
         include_when:
-          amenity:
-            - ranger_station
-        exclude_when:
-          highway:
-            - trailhead
+          amenity: ranger_station
         attributes:
           - key: OSM_TYPE
             value: "node"
@@ -168,8 +205,7 @@ layers:
         geometry: polygon_centroid_if_convex
         min_zoom: 5
         include_when:
-          amenity:
-            - ranger_station
+          amenity: ranger_station
         attributes:
           - key: OSM_TYPE
             value: "way"
@@ -191,8 +227,9 @@ layers:
         geometry: point
         min_zoom: 7
         include_when:
-          highway:
-            - trailhead
+          highway: trailhead
+        exclude_when:
+          amenity: ranger_station
         attributes:
           - key: OSM_ID
             value: "${feature.id}"
@@ -214,8 +251,6 @@ layers:
             tag_value: hiking
           - key: horse
             tag_value: horse
-          - key: information
-            tag_value: information
           - key: mtb
             tag_value: mtb
           - key: name
@@ -232,6 +267,32 @@ layers:
             tag_value: snowmobile
           - key: wheelchair
             tag_value: wheelchair
+      # `canoe=put_in` is like `highway=trailhead` for water trails
+      - source: osm
+        geometry: point
+        min_zoom: 7
+        include_when:
+          canoe: put_in
+        exclude_when:
+          amenity: ranger_station
+          highway: trailhead
+        attributes:
+          - key: OSM_ID
+            value: "${feature.id}"
+          - key: access
+            tag_value: access
+          - key: canoe
+            tag_value: canoe
+          - key: dog
+            tag_value: dog
+          - key: name
+            tag_value: name
+          - key: opening_hours
+            tag_value: opening_hours
+          - key: operator
+            tag_value: operator
+          - key: wheelchair
+            tag_value: wheelchair
       - source: osm
         geometry: point
         # route markers are abundant so restrict to higher zooms
@@ -241,10 +302,9 @@ layers:
             - route_marker
             - guidepost
         exclude_when:
-          amenity:
-            - ranger_station
-          highway:
-            - trailhead
+          amenity: ranger_station
+          canoe: put_in
+          highway: trailhead
         attributes:
           - key: OSM_ID
             value: "${feature.id}"

--- a/layers/osmus_trails.yml
+++ b/layers/osmus_trails.yml
@@ -12,14 +12,9 @@ layers:
         geometry: line
         min_zoom: 5
         include_when:
-          &trail_include_filter
           highway:
-            # include any path-like features
             - bridleway
-            - cycleway
-            - footway
             - path
-            - steps
             - via_ferrata
           __all__:
             # we only care about tracks if they have some trail access tag
@@ -31,22 +26,17 @@ layers:
               foot: __any__
               horse: __any__
               piste:type: __any__
-              ski: __any__
               ski:nordic: __any__
               snowmobile: __any__
               wheelchair: __any__
           __all__:
-            # include roads that are part of canoe portages 
+            # include any roads or paths that are part of canoe portages 
             - highway: __any__
             - canoe: portage
         exclude_when:
-          &trail_exclude_filter
-          # ignore sidewalks, crossings, access aisles, etc.
-          footway: __any__
-          golf: cartpath
-          # outdoor stuff only
           indoor: __any__
         attributes:
+          &trail_attributes
           - key: OSM_ID
             value: "${feature.id}"
           - key: access
@@ -81,6 +71,8 @@ layers:
             tag_value: motor_vehicle
           - key: mtb
             tag_value: mtb
+          - key: name
+            tag_value: name
           - key: oneway
             tag_value: oneway
           - key: oneway:bicycle
@@ -97,8 +89,6 @@ layers:
             tag_value: ramp:wheelchair
           - key: sac_scale
             tag_value: sac_scale
-          - key: ski
-            tag_value: ski
           - key: ski:nordic
             tag_value: ski:nordic
           - key: smoothness
@@ -125,6 +115,28 @@ layers:
             tag_value: wheelchair
           - key: width
             tag_value: width
+      - source: osm
+        geometry: line
+        min_zoom: 5
+        include_when:
+          highway:
+            - footway
+            - steps
+        exclude_when:
+          # ignore sidewalks, crossings, access aisles, etc.
+          footway: __any__
+          indoor: __any__
+        attributes: *trail_attributes
+      - source: osm
+        geometry: line
+        min_zoom: 5
+        include_when:
+          highway: cycleway
+        exclude_when:
+          # ignore bike lanes that are part of roads
+          cycleway: lane
+          indoor: __any__
+        attributes: *trail_attributes
       - source: osm
         geometry: line
         min_zoom: 5
@@ -157,24 +169,6 @@ layers:
             tag_value: tunnel
           - key: width
             tag_value: width
-  - id: trail_name
-    features:
-      - source: osm
-        geometry: line
-        min_zoom: 10
-        include_when:
-          __all__:
-            name: __any__
-            __any__: *trail_include_filter
-        exclude_when: *trail_exclude_filter
-        attributes:
-          - key: name
-            tag_value: name
-    tile_post_process:
-      merge_line_strings:
-        min_length: 10
-        tolerance: 0.1
-        buffer: 5
   - id: trail_poi
     features:
       # collect ranger stations mapped as nodes
@@ -259,8 +253,6 @@ layers:
             tag_value: opening_hours
           - key: operator
             tag_value: operator
-          - key: ski
-            tag_value: ski
           - key: ski:nordic
             tag_value: ski:nordic
           - key: snowmobile
@@ -330,8 +322,6 @@ layers:
             tag_value: name
           - key: operator
             tag_value: operator
-          - key: ski
-            tag_value: ski
           - key: ski:nordic
             tag_value: ski:nordic
           - key: snowmobile


### PR DESCRIPTION
- Alphabetize and adjust tags
- Add points for centers of ranger stations mapped as areas
- Include ranger stations at lower zooms
- Add trail marker/guidepost POIs at zoom >=12
- Add water trail data: highways with `canoe=portage` and waterways with `canoe=*`
- Remove trail label layer—we can just use the regular trails layer for now