### PR TITLE
Update osmus_trails.yml for portage tag

### DIFF
--- a/layers/osmus_trails.yml
+++ b/layers/osmus_trails.yml
@@ -32,7 +32,7 @@ layers:
           - __all__:
             # include any roads or paths that are part of canoe portages 
             - highway: __any__
-            - canoe: portage
+            - portage: __any__
         exclude_when:
           indoor: __any__
           man_made: pier

--- a/layers/osmus_trails.yml
+++ b/layers/osmus_trails.yml
@@ -50,8 +50,6 @@ layers:
             tag_value: bicycle
           - key: bridge
             tag_value: bridge
-          - key: canoe
-            tag_value: canoe
           - key: check_date
             tag_value: check_date
           - key: dog
@@ -90,6 +88,8 @@ layers:
             tag_value: operator
           - key: piste:type
             tag_value: piste:type
+          - key: portage
+            tag_value: portage
           - key: ramp:bicycle
             tag_value: ramp:bicycle
           - key: ramp:wheelchair
@@ -196,6 +196,8 @@ layers:
             tag_value: oneway:canoe
           - key: name
             tag_value: name
+          - key: portage
+            tag_value: portage
           - key: survey:date
             tag_value: survey:date
           - key: tidal

--- a/layers/osmus_trails.yml
+++ b/layers/osmus_trails.yml
@@ -169,6 +169,7 @@ layers:
               - canoe_pass
               - fairway
               - link
+              - flowline
             - canoe: __any__
         exclude_when:
           indoor: __any__


### PR DESCRIPTION
portage=* is the new way to tag canoe portages.

Also added support for the experimental tag waterway=flowline.